### PR TITLE
Fix header positioning

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -92,9 +92,9 @@
           <a href="{{ url }}{{lang}}/associates/">
             <div class="tint">
               <img class="img-responsive" src = "{{ url }}data/images/associates_new.png" alt = "{{strings['base6']}}" title = "{{strings['base6']}}">
-            </div>
-            <div class="centered">
-              <h2>{{strings['base6']}}</h2>
+              <div class="centered">
+                <h2>{{strings['base6']}}</h2>
+              </div>
             </div>
           </a>
         </div>
@@ -104,9 +104,9 @@
           <a href="{{ url }}{{lang}}/visual/">
             <div class="tint">
               <img class="img-responsive" src = "{{ url }}data/images/visual_new.png" alt = "{{strings['base13']}}" title = "{{strings['base13']}}">
-            </div>
-            <div class="centered">
-              <h2>{{strings['base13']}}</h2>
+              <div class="centered">
+                <h2>{{strings['base13']}}</h2>
+              </div>
             </div>
           </a>
         </div>
@@ -119,9 +119,9 @@
           <a href="{{ url }}{{lang}}/calculator/">
             <div class="tint">
               <img class="img-responsive" src = "{{ url }}data/images/calculator_new.png" alt = "{{strings['base5']}}" title = "{{strings['base5']}}">
-            </div>
-            <div class="centered">
-              <h2>{{strings['base5']}}</h2>
+              <div class="centered">
+                <h2>{{strings['base5']}}</h2>
+              </div>
             </div>
           </a>
         </div>
@@ -131,9 +131,9 @@
           <a href="{{ url }}{{lang}}/misc/">
             <div class="tint">
               <img class="img-responsive" src = "{{ url }}data/images/misc_new.png" alt = "{{strings['base17']}}" title = "{{strings['base17']}}">
-            </div>
-            <div class="centered">
-              <h2>{{strings['base17']}}</h2>
+              <div class="centered">
+                <h2>{{strings['base17']}}</h2>
+              </div>
             </div>
           </a>
         </div>


### PR DESCRIPTION
Position headers relative to images (to prevent from falling outside when device width is more than 490px and less than 992px ).
<img src="https://user-images.githubusercontent.com/33612458/65520431-d68eb880-dee7-11e9-8c18-158ec6bab7c7.png" width="450">
