### PR TITLE
Fix radio input and checkbox input positioning

### DIFF
--- a/data/css/radio-and-checkbox.css
+++ b/data/css/radio-and-checkbox.css
@@ -1,0 +1,19 @@
+.checkbox label,
+.radio label {
+  font-size: 0.86em;
+  padding-left: 0;
+  margin-right: 5px;
+}
+
+.checkbox input[type=checkbox],
+.radio input[type=radio] {
+  position: relative;
+  top: -1px;
+  margin-top: 0;
+  margin-left: 0;
+  vertical-align: middle;
+}
+
+.checkbox input[type=checkbox] {
+  margin-right: 2px;
+}

--- a/templates/associates.html
+++ b/templates/associates.html
@@ -24,39 +24,35 @@
         </div>
         <!-- The checkbox for model selection -->
         <div class="checkbox">
-          <p><small><em>{{strings['similar3']}}</em></small></p>
+          <p><em>{{strings['similar3']}}</em></p>
           <fieldset>
-            <small>
-              <!-- A cicle for models to work with -->
-              {%- for m in models %}
-              <label>
-              <input type="checkbox" {%if m in usermodels %}checked{% endif %} name="model" value="{{ m }}">{{ strings[models[m]] }}
-              </label>
-              {%- endfor %}
-            </small>
+            <!-- A cicle for models to work with -->
+            {%- for m in models %}
+            <label>
+            <input type="checkbox" {%if m in usermodels %}checked{% endif %} name="model" value="{{ m }}">{{ strings[models[m]] }}
+            </label>
+            {%- endfor %}
           </fieldset>
         </div>
         <!-- If post tags are used, one can select the pos in the results-->
         {% if tags -%}
         <!-- The header "Show only:" -->
-        <p><small><em>{{strings['similar9']}}</em></small></p>
-        <!-- radiobuttons for pos selection -->
         <div class="radio">
-          <small>
-            <!-- Within the cicle buttons with tags are added for the selected posses in the "tags.tsv" file. -->
-            {%- for tag in tags2show %}
-            <label>
-            <input type="radio" name="pos" {% if tag in userpos %}checked{% endif %} value="{{ tag }}"> {{strings[tags2show[tag]]}}
-            </label>
-            {%- endfor %}
-            <!-- And outside the cicle - buttons for all the possible posses and for the query pos. -->
-            <label>
-            <input type="radio" name="pos" {% if not userpos %}checked{% endif %} value="ALL"> {{strings['similar14']}}
-            </label>
-            <label>
-            <input type="radio" name="pos" {% if 'Q' in userpos %}checked{% endif %} value="Q"> {{strings['similar19']}}
-            </label>
-          </small>
+          <p><em>{{strings['similar9']}}</em></p>
+          <!-- radiobuttons for pos selection -->
+          <!-- Within the cicle buttons with tags are added for the selected posses in the "tags.tsv" file. -->
+          {%- for tag in tags2show %}
+          <label>
+          <input type="radio" name="pos" {% if tag in userpos %}checked{% endif %} value="{{ tag }}"> {{strings[tags2show[tag]]}}
+          </label>
+          {%- endfor %}
+          <!-- And outside the cicle - buttons for all the possible posses and for the query pos. -->
+          <label>
+          <input type="radio" name="pos" {% if not userpos %}checked{% endif %} value="ALL"> {{strings['similar14']}}
+          </label>
+          <label>
+          <input type="radio" name="pos" {% if 'Q' in userpos %}checked{% endif %} value="Q"> {{strings['similar19']}}
+          </label>
         </div>
         {%- endif %}
         <!-- Button "Find similar words!" is placed in <form> to be able to send data to the server -->
@@ -80,15 +76,13 @@
     </h3>
     <!-- Checkbox for frequency selection-->
     <div class="checkbox">
-      <p><small><em>{{strings['frequency1']}}</em></small></p>
-      <small>
+      <p><em>{{strings['frequency1']}}</em></p>
       <label class="frequency-high" title="{{strings['frequency5']}}">
       <input id="high" type="checkbox" checked>{{ strings['frequency2']}}</label>
       <label class="frequency-mid" title="{{strings['frequency6']}}">
       <input id="mid" type="checkbox" checked>{{ strings['frequency3'] }}</label>
       <label class="frequency-low" title="{{strings['frequency7']}}">
       <input id="low" type="checkbox">{{ strings['frequency4'] }}</label>
-      </small>
     </div>
     <!-- Featuring list of results
       Every model is allocated a column to be shown in, the link to it is given

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,7 @@
   <link href="{{ url }}data/css/typeahead.css/" rel="stylesheet">
   <link href="{{ url }}data/css/avatar.css/" rel="stylesheet" media="screen">
   <link href="{{ url }}data/css/results.css/" rel="stylesheet" media="screen">
+  <link href="{{ url }}data/css/radio-and-checkbox.css/" rel="stylesheet" media="screen">
   {%- endblock styles -%}
   {%- endblock head %}
 </head>

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -52,15 +52,13 @@
         <div class = "row" id="result" data-result='{{ frequencies|tojson }}' data-visible="{{ visible_neighbors }}">
           <!-- Checkbox for frequency selection-->
           <div class="checkbox">
-            <p><small><em>{{strings['frequency1']}}</em></small></p>
-            <small>
+            <p><em>{{strings['frequency1']}}</em></p>
             <label class="frequency-high" title="{{strings['frequency5']}}">
             <input id="high" type="checkbox" checked>{{ strings['frequency2']}}</label>
             <label class="frequency-mid" title="{{strings['frequency6']}}">
             <input id="mid" type="checkbox" checked>{{ strings['frequency3'] }}</label>
             <label class="frequency-low" title="{{strings['frequency7']}}">
             <input id="low" type="checkbox">{{ strings['frequency4'] }}</label>
-            </small>
           </div>
           {% for model in analogy_value -%}
           <div class = "col-md-5">
@@ -118,22 +116,19 @@
       </div>
       <!-- Model selection -->
       <div class="checkbox">
-        <p><small><em>{{strings['similar3']}}</em></small></p>
+        <p><em>{{strings['similar3']}}</em></p>
         <fieldset>
-          <small>
           {%- for m in models %}
           <label>
           <input type="checkbox" {%if m in usermodels %}checked{% endif %} name="calcmodel" value="{{ m }}">{{ strings[models[m]] }}
           </label>
           {%- endfor %}
-          </small>
         </fieldset>
       </div>
       <!-- Pos selection -->
       {% if tags -%}
-      <p><small><em>{{strings['similar9']}}</em></small></p>
       <div class="radio">
-        <small>
+        <p><em>{{strings['similar9']}}</em></p>
         {%- for tag in tags2show %}
         <label>
         <input type="radio" name="pos" value="{{ tag }}" {% if tag in userpos %} checked {% endif %}> {{strings[tags2show[tag]]}}
@@ -142,7 +137,6 @@
         <label>
         <input type="radio" name="pos" value="ALL" {% if not userpos %} checked {% endif %}> {{strings['similar14']}}
         </label>
-        </small>
       </div>
       {%- endif %}
       <!-- button "Calculate!" -->
@@ -174,15 +168,13 @@
       <div class = "row" id="result" data-result='{{ frequencies|tojson }}' data-visible="{{ visible_neighbors }}">
         <!-- Checkbox for frequency selection -->
         <div class="checkbox">
-          <p><small><em>{{strings['frequency1']}}</em></small></p>
-          <small>
+          <p><em>{{strings['frequency1']}}</em></p>
           <label class="frequency-high" title="{{strings['frequency5']}}">
           <input id="high" type="checkbox" checked>{{ strings['frequency2']}}</label>
           <label class="frequency-mid" title="{{strings['frequency6']}}">
           <input id="mid" type="checkbox" checked>{{ strings['frequency3'] }}</label>
           <label class="frequency-low" title="{{strings['frequency7']}}">
           <input id="low" type="checkbox">{{ strings['frequency4'] }}</label>
-          </small>
         </div>
         {% for model in calc_value -%}
         <div class = "col-md-6">
@@ -241,22 +233,21 @@
         {% endif -%}
         <!-- Choose the model -->
       <div class="checkbox">
-        <p><small><em>{{strings['similar3']}}</em></small></p>
+        <p><em>{{strings['similar3']}}</em></p>
         <fieldset>
-          <small>
+          
           {%- for m in models %}
           <label>
           <input type="checkbox" {%if m in usermodels %}checked{% endif %} name="calcmodel" value="{{ m }}">{{ strings[models[m]] }}
           </label>
           {%- endfor %}
-          </small>
+          
         </fieldset>
       </div>
       {% if tags -%}
       <!-- Choose the pos -->
-      <p><small><em>{{strings['similar9']}}</em></small></p>
       <div class="radio">
-        <small>
+        <p><em>{{strings['similar9']}}</em></p>
         {%- for tag in tags2show %}
         <label>
         <input type="radio" name="calcpos" value="{{ tag }}" {% if tag in userpos %} checked {% endif %}> {{strings[tags2show[tag]]}}
@@ -265,7 +256,6 @@
         <label>
         <input type="radio" name="calcpos" value="ALL" {% if not userpos %} checked {% endif %}> {{strings['similar14']}}
         </label>
-        </small>
       </div>
       {%- endif %}
       <button type="submit" class="btn btn-primary" name="calc_query" value = "{{strings['calc18']}}">{{strings['calc18']}}</button>

--- a/templates/home.html
+++ b/templates/home.html
@@ -28,8 +28,7 @@
 </h3>
 <!-- Checkbox for frequency selection -->
 <div class="checkbox">
-  <p><small><em>{{strings['frequency1']}}</em></small></p>
-  <small>
+  <p><em>{{strings['frequency1']}}</em></p>
   <label class="frequency-high" title="{{strings['frequency5']}}">
   <input id="high" type="checkbox" checked>{{ strings['frequency2']}}
   </label>
@@ -37,7 +36,6 @@
   <input id="mid" type="checkbox" checked>{{ strings['frequency3'] }}</label>
   <label class="frequency-low" title="{{strings['frequency7']}}">
   <input id="low" type="checkbox">{{ strings['frequency4'] }}</label>
-  </small>
 </div>
 <!-- If the word is not present in the model but its embedding is inferred from its characters -->
 {%- if model in inferred %}

--- a/templates/similar.html
+++ b/templates/similar.html
@@ -17,14 +17,12 @@
         <input id="sim_history" name="sim_history" type="hidden" value="{% if value %} {{ str_sim_history }} {% endif %}">
       </div>
       <div class="radio">
-        <p><small><em>{{strings['similar3']}}</em></small></p>
-        <small>
+        <p><em>{{strings['similar3']}}</em></p>
         {%- for m in models %}
         <label>
         <input type="radio" name="simmodel" {%if m in usermodels %}checked{% endif %} value="{{ m }}">{{ strings[models[m]] }}
         </label>
         {%- endfor %}
-        </small>
       </div>
       <button type="submit" class="btn btn-primary" name="query">{{strings['similar27']}}</button>
     </form>

--- a/templates/visual.html
+++ b/templates/visual.html
@@ -29,15 +29,13 @@
     </div>
   </div>
   <div class="checkbox">
-    <p><small><em>{{strings['similar3']}}</em></small></p>
+    <p><em>{{strings['similar3']}}</em></p>
     <fieldset>
-      <small>
       {% for m in models %}
       <label>
       <input type="checkbox" {%if m in usermodels %}checked{% endif %} name="model" value="{{ m }}">{{ strings[models[m]] }}
       </label>
       {% endfor %}
-      </small>
     </fieldset>
   </div>
   <button type="submit" class="btn btn-primary">{{strings['visual15']}}</button>

--- a/templates/wordpage.html
+++ b/templates/wordpage.html
@@ -36,15 +36,13 @@
     </h2>
     <!-- Checkbox for frequency selection -->
     <div class="checkbox">
-      <p><small><em>{{strings['frequency1']}}</em></small></p>
-      <small>
+      <p><em>{{strings['frequency1']}}</em></p>
       <label class="frequency-high" title="{{strings['frequency5']}}">
       <input id="high" type="checkbox" checked>{{ strings['frequency2']}}</label>
       <label class="frequency-mid" title="{{strings['frequency6']}}">
       <input id="mid" type="checkbox" checked>{{ strings['frequency3'] }}</label>
       <label class="frequency-low" title="{{strings['frequency7']}}">
       <input id="low" type="checkbox">{{ strings['frequency4'] }}</label>
-      </small>
     </div>
     <!-- If the word is not present in the model but its embedding is inferred from its characters -->
     {%- if model in inferred %}


### PR DESCRIPTION
Align inputs `type="radio"` and inputs `type="checkbox"` and their labels. Also, get rid of `<small>` tag in these cases, set font size with CSS instead.